### PR TITLE
fix issue #39: reconcile changes for tunnel spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ testbin/*
 *.swp
 *.swo
 *~
+
+# used for development
+secrets


### PR DESCRIPTION
fixes https://github.com/adyanth/cloudflare-operator/issues/39

- Adds lots of default values to the deployment spec. Unless I'm mistaken these are all default values and I'm not changing any values (just making them explicit). This is needed for properly comparing diffs
- for simplicity, we are only diffing the deployment's `spec.template.spec` . This covers a larger number of use cases than is currently compared (for example updating the container image) but doesn't cover the wider deployment spec in its entirety. Diffiing the whole deployment is quite a bit more involved and I'd like to get this in to look at other issues before circling back to this
